### PR TITLE
Move extern specizialization out of baseheader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(HEADER_FILES
     src/Elasticity/init.h
 
     src/Elasticity/finiteelement/FiniteElement.h
+    src/Elasticity/finiteelement/FiniteElement[all].h
     src/Elasticity/finiteelement/FiniteElement[Edge].h
     src/Elasticity/finiteelement/FiniteElement[Hexahedron].h
     src/Elasticity/finiteelement/FiniteElement[Quad].h
@@ -26,6 +27,7 @@ set(HEADER_FILES
     src/Elasticity/impl/CorotationalFEM.inl
     src/Elasticity/impl/ElasticityTensor.h
     src/Elasticity/impl/ElementStiffnessMatrix.h
+    src/Elasticity/impl/LinearFEM[all].h
     src/Elasticity/impl/LinearFEM.h
     src/Elasticity/impl/LinearFEM.inl
     src/Elasticity/impl/MatrixTools.h

--- a/src/Elasticity/finiteelement/FiniteElement[all].h
+++ b/src/Elasticity/finiteelement/FiniteElement[all].h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <Elasticity/finiteelement/FiniteElement[Edge].h>
+#include <Elasticity/finiteelement/FiniteElement[Hexahedron].h>
+#include <Elasticity/finiteelement/FiniteElement[Quad].h>
+#include <Elasticity/finiteelement/FiniteElement[Tetrahedron].h>
+#include <Elasticity/finiteelement/FiniteElement[Triangle].h>

--- a/src/Elasticity/impl/CorotationalFEM.h
+++ b/src/Elasticity/impl/CorotationalFEM.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Elasticity/impl/LinearFEM.h>
+#include <Elasticity/impl/LinearFEM[all].h>
 
 namespace elasticity
 {

--- a/src/Elasticity/impl/LinearFEM.cpp
+++ b/src/Elasticity/impl/LinearFEM.cpp
@@ -1,14 +1,9 @@
 #define ELASTICITY_LINEARFEM_CPP
 
-#include <Elasticity/impl/LinearFEM.inl>
 #include <Elasticity/config.h>
+#include <Elasticity/finiteelement/FiniteElement[all].h>
+#include <Elasticity/impl/LinearFEM.inl>
 #include <sofa/defaulttype/VecTypes.h>
-
-#include <Elasticity/finiteelement/FiniteElement[Edge].h>
-#include <Elasticity/finiteelement/FiniteElement[Hexahedron].h>
-#include <Elasticity/finiteelement/FiniteElement[Quad].h>
-#include <Elasticity/finiteelement/FiniteElement[Tetrahedron].h>
-#include <Elasticity/finiteelement/FiniteElement[Triangle].h>
 
 namespace elasticity
 {

--- a/src/Elasticity/impl/LinearFEM.h
+++ b/src/Elasticity/impl/LinearFEM.h
@@ -9,14 +9,6 @@
 
 #include <Elasticity/impl/ElasticityTensor.h>
 
-#if !defined(ELASTICITY_LINEARFEM_CPP)
-#include <Elasticity/finiteelement/FiniteElement[Edge].h>
-#include <Elasticity/finiteelement/FiniteElement[Hexahedron].h>
-#include <Elasticity/finiteelement/FiniteElement[Quad].h>
-#include <Elasticity/finiteelement/FiniteElement[Tetrahedron].h>
-#include <Elasticity/finiteelement/FiniteElement[Triangle].h>
-#endif
-
 namespace elasticity
 {
 
@@ -107,15 +99,4 @@ protected:
     const sofa::type::vector<ElementStiffness>& stiffnessMatrices() const;
 };
 
-#if !defined(ELASTICITY_LINEARFEM_CPP)
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec1Types, sofa::geometry::Edge>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec2Types, sofa::geometry::Edge>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Edge>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec2Types, sofa::geometry::Triangle>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Triangle>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec2Types, sofa::geometry::Quad>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Quad>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
-extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
-#endif
 }

--- a/src/Elasticity/impl/LinearFEM.h
+++ b/src/Elasticity/impl/LinearFEM.h
@@ -9,11 +9,13 @@
 
 #include <Elasticity/impl/ElasticityTensor.h>
 
+#if !defined(ELASTICITY_LINEARFEM_CPP)
 #include <Elasticity/finiteelement/FiniteElement[Edge].h>
 #include <Elasticity/finiteelement/FiniteElement[Hexahedron].h>
 #include <Elasticity/finiteelement/FiniteElement[Quad].h>
 #include <Elasticity/finiteelement/FiniteElement[Tetrahedron].h>
 #include <Elasticity/finiteelement/FiniteElement[Triangle].h>
+#endif
 
 namespace elasticity
 {

--- a/src/Elasticity/impl/LinearFEM.h
+++ b/src/Elasticity/impl/LinearFEM.h
@@ -9,6 +9,12 @@
 
 #include <Elasticity/impl/ElasticityTensor.h>
 
+#include <Elasticity/finiteelement/FiniteElement[Edge].h>
+#include <Elasticity/finiteelement/FiniteElement[Hexahedron].h>
+#include <Elasticity/finiteelement/FiniteElement[Quad].h>
+#include <Elasticity/finiteelement/FiniteElement[Tetrahedron].h>
+#include <Elasticity/finiteelement/FiniteElement[Triangle].h>
+
 namespace elasticity
 {
 
@@ -100,12 +106,6 @@ protected:
 };
 
 #if !defined(ELASTICITY_LINEARFEM_CPP)
-#include <Elasticity/finiteelement/FiniteElement[Edge].h>
-#include <Elasticity/finiteelement/FiniteElement[Hexahedron].h>
-#include <Elasticity/finiteelement/FiniteElement[Quad].h>
-#include <Elasticity/finiteelement/FiniteElement[Tetrahedron].h>
-#include <Elasticity/finiteelement/FiniteElement[Triangle].h>
-
 extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec1Types, sofa::geometry::Edge>;
 extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec2Types, sofa::geometry::Edge>;
 extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Edge>;

--- a/src/Elasticity/impl/LinearFEM[all].h
+++ b/src/Elasticity/impl/LinearFEM[all].h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Elasticity/config.h>
+#include <Elasticity/impl/LinearFEM.h>
+#include <Elasticity/finiteelement/FiniteElement[all].h>
+
+namespace elasticity
+{
+#if !defined(ELASTICITY_LINEARFEM_CPP)
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec1Types, sofa::geometry::Edge>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec2Types, sofa::geometry::Edge>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Edge>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec2Types, sofa::geometry::Triangle>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Triangle>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec2Types, sofa::geometry::Quad>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Quad>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Tetrahedron>;
+extern template class ELASTICITY_API LinearFEM<sofa::defaulttype::Vec3Types, sofa::geometry::Hexahedron>;
+#endif
+}


### PR DESCRIPTION
Not sure it is better, but I always find it ugly to hardcode the extern types in the base header .

Only last commit is relevant.